### PR TITLE
Implement partial receipt handling for purchase orders

### DIFF
--- a/src/main/java/com/medicorex/controller/PurchaseOrderController.java
+++ b/src/main/java/com/medicorex/controller/PurchaseOrderController.java
@@ -158,4 +158,10 @@ public class PurchaseOrderController {
 
         return ResponseEntity.ok(purchaseOrderService.updateStatusWithComments(id, status, comments));
     }
+
+    @GetMapping("/eligible-for-receiving")
+    @PreAuthorize("hasAnyRole('HOSPITAL_MANAGER', 'PROCUREMENT_OFFICER')")
+    public ResponseEntity<List<PurchaseOrderDTO>> getEligibleForReceiving() {
+        return ResponseEntity.ok(purchaseOrderService.getEligibleForReceiving());
+    }
 }

--- a/src/main/java/com/medicorex/dto/PurchaseOrderLineDTO.java
+++ b/src/main/java/com/medicorex/dto/PurchaseOrderLineDTO.java
@@ -23,5 +23,6 @@ public class PurchaseOrderLineDTO {
     private BigDecimal taxPercentage;
     private BigDecimal lineTotal;
     private Integer receivedQuantity;
+    private Integer remainingQuantity;
     private String notes;
 }

--- a/src/main/java/com/medicorex/entity/PurchaseOrder.java
+++ b/src/main/java/com/medicorex/entity/PurchaseOrder.java
@@ -105,10 +105,11 @@ public class PurchaseOrder {
     }
 
     public enum POStatus {
-        DRAFT,
-        APPROVED,
-        SENT,
-        RECEIVED,
-        CANCELLED
+        DRAFT,              // Initial state, being created
+        APPROVED,           // Approved by manager
+        SENT,              // Sent to supplier
+        PARTIALLY_RECEIVED, // Some items received, waiting for remaining
+        RECEIVED,          // All items fully received
+        CANCELLED          // Order cancelled
     }
 }

--- a/src/main/java/com/medicorex/repository/PurchaseOrderRepository.java
+++ b/src/main/java/com/medicorex/repository/PurchaseOrderRepository.java
@@ -53,4 +53,24 @@ public interface PurchaseOrderRepository extends JpaRepository<PurchaseOrder, Lo
     @Query("SELECT MAX(CAST(SUBSTRING(po.poNumber, 4) AS int)) FROM PurchaseOrder po " +
             "WHERE po.poNumber LIKE :prefix")
     Integer findMaxPoNumberSequence(@Param("prefix") String prefix);
+
+    /**
+     * Find all partially received purchase orders
+     */
+    @Query("SELECT po FROM PurchaseOrder po WHERE po.status = 'PARTIALLY_RECEIVED'")
+    Page<PurchaseOrder> findPartiallyReceived(Pageable pageable);
+
+    /**
+     * Find POs with remaining quantities
+     */
+    @Query("SELECT DISTINCT po FROM PurchaseOrder po " +
+            "JOIN po.lines line " +
+            "WHERE line.remainingQuantity > 0 " +
+            "AND po.status IN ('SENT', 'PARTIALLY_RECEIVED')")
+    List<PurchaseOrder> findPurchaseOrdersWithRemainingItems();
+
+    @Query("SELECT po FROM PurchaseOrder po " +
+            "WHERE po.status IN ('SENT', 'PARTIALLY_RECEIVED') " +
+            "ORDER BY po.orderDate DESC")
+    List<PurchaseOrder> findEligibleForReceiving();
 }

--- a/src/main/java/com/medicorex/service/procurement/PurchaseOrderService.java
+++ b/src/main/java/com/medicorex/service/procurement/PurchaseOrderService.java
@@ -333,6 +333,16 @@ public class PurchaseOrderService {
     }
 
     /**
+     * Get eligible purchase orders for receiving
+     */
+    @Transactional(readOnly = true)
+    public List<PurchaseOrderDTO> getEligibleForReceiving() {
+        return purchaseOrderRepository.findEligibleForReceiving().stream()
+                .map(this::convertToDTO)
+                .collect(Collectors.toList());
+    }
+
+    /**
      * Request approval for purchase order (sends notification to managers)
      */
     public void requestApproval(Long id) {
@@ -730,6 +740,7 @@ public class PurchaseOrderService {
                 .taxPercentage(line.getTaxPercentage())
                 .lineTotal(line.getLineTotal())
                 .receivedQuantity(line.getReceivedQuantity())
+                .remainingQuantity(line.getRemainingQuantity())  // ✨ NEW FIELD
                 .notes(line.getNotes())
                 .build();
     }


### PR DESCRIPTION
Adds support for tracking remaining quantities on purchase order lines, enables multiple receipts per PO, and introduces the PARTIALLY_RECEIVED status. Updates database schema, entities, DTOs, repository queries, and service logic to support partial fulfillment and notifications for partial receipts. Also adds an endpoint to fetch eligible purchase orders for receiving.